### PR TITLE
Python.h in 3.4+ contains C++ templates, so using extern "C" causes errors.

### DIFF
--- a/kyotocabinet3.cc
+++ b/kyotocabinet3.cc
@@ -17,11 +17,11 @@
 
 namespace kc = kyotocabinet;
 
+#include <Python.h>
 extern "C" {
 
 #undef _POSIX_C_SOURCE
 #undef _XOPEN_SOURCE
-#include <Python.h>
 #include <structmember.h>
 
 


### PR DESCRIPTION
See e.g.
https://github.com/luispedro/imread/commit/f3732f1cb787b037a6455d180cafe678a7f5934e
for a similar fix.

I tested and the compiled lib at least works in basic things after the change but haven't made any rigorous checks.